### PR TITLE
Make the library compatible with both Python2.x and Python3.x

### DIFF
--- a/investigate/__init__.py
+++ b/investigate/__init__.py
@@ -1,1 +1,1 @@
-from investigate import *
+from .investigate import *

--- a/investigate/investigate.py
+++ b/investigate/investigate.py
@@ -1,8 +1,13 @@
+from future.standard_library import install_aliases
+install_aliases()
+
 import json
 import re
 import requests
-import urlparse, urllib
 import datetime, time
+from future.utils import iteritems
+from urllib.parse import urljoin, quote_plus
+
 
 class Investigate(object):
     BASE_URL = 'https://investigate.api.umbrella.com/'
@@ -58,7 +63,7 @@ class Investigate(object):
         '''A generic method to make GET requests to the OpenDNS Investigate API
         on the given URI.
         '''
-        return self._session.get(urlparse.urljoin(Investigate.BASE_URL, uri),
+        return self._session.get(urljoin(Investigate.BASE_URL, uri),
             params=params, headers=self._auth_header, proxies=self.proxies
         )
 
@@ -67,7 +72,7 @@ class Investigate(object):
         on the given URI.
         '''
         return self._session.post(
-            urlparse.urljoin(Investigate.BASE_URL, uri),
+            urljoin(Investigate.BASE_URL, uri),
             params=params, data=data, headers=self._auth_header,
             proxies=self.proxies
         )
@@ -90,7 +95,7 @@ class Investigate(object):
         return self._request_parse(self.post, uri, params, data)
 
     def _get_categorization(self, domain, labels):
-        uri = urlparse.urljoin(self._uris['categorization'], domain)
+        uri = urljoin(self._uris['categorization'], domain)
         params = {'showLabels': True} if labels else {}
         return self.get_parse(uri, params)
 
@@ -185,7 +190,7 @@ class Investigate(object):
         resp_json = self.get_parse(uri)
 
         # parse out the domain names
-        return [ val for d in resp_json for key, val in d.iteritems() if key == 'name' ]
+        return [ val for d in resp_json for key, val in iteritems(d) if key == 'name' ]
 
     def domain_whois(self, domain):
         '''Gets whois information for a domain'''
@@ -233,7 +238,7 @@ class Investigate(object):
 
     def search(self, pattern, start=None, limit=None, include_category=None):
         '''Searches for domains that match a given pattern'''
-        
+
         params = dict()
 
         if start is None:
@@ -245,13 +250,13 @@ class Investigate(object):
             params['start'] = int(time.mktime(start.timetuple()) * 1000)
         else:
             raise Investigate.SEARCH_ERR
-        
+
         if limit is not None and isinstance(limit, int):
             params['limit'] = limit
         if include_category is not None and isinstance(include_category, bool):
             params['includeCategory'] = str(include_category).lower()
 
-        uri = self._uris['search'].format(urllib.quote_plus(pattern))
+        uri = self._uris['search'].format(quote_plus(pattern))
 
         return self.get_parse(uri, params)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages  # Always prefer setuptools over dis
 
 setup(
     name='investigate',
-    version='1.3.0',
+    version='1.4.0',
     description='Python interface for the OpenDNS Investigate API',
     url='https://github.com/opendns/pyinvestigate',
     author='Skyler Hawthorne, Thibault Reuille',
@@ -12,5 +12,5 @@ setup(
     license='MIT',
     keywords='opendns investigate',
     packages=find_packages(),
-    install_requires=['requests'],
+    install_requires=['requests', 'future']
 )


### PR DESCRIPTION
Update syntax and make use of `future` package to make the library compatible with both Python2.x and Python 3.x. 

I ran the test with pytest on Python2.7 and Python3.6, all the test cases passed except `test_sample` and `test_sample_artifacts` as my API key doesn't have access to artifact data. 

I've also updated the version of this library to 1.4.0. I think that is necessary as this change introduces support for new Python version. 